### PR TITLE
Simpler style sugar

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,13 +47,14 @@ function render ({props}) {
 
 ### Style objects
 
-Passing an object as the `style` prop to an element will cause that object to be stringified by [toStyle](https://github.com/radubrehar/toStyle). E.g.
+Passing an object as the `style` prop to an element will cause that object to be stringified and each camel cased property will get dashed. E.g.
 
 ```javascript
 import colors from 'lib/colors'
 
 function render ({props, children}) {
-  return <button style={{color: props.primary ? colors.primary : colors.accent}}>{children}</button>
+  return <button style={{backgroundColor: props.primary ? colors.primary : colors.accent}}>{children}</button>
+  // style = 'background-color:#fff'
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-tape-runner": "^2.0.0",
     "standard": "^5.1.0",
     "tap-spec": "^4.1.1",
-    "tape": "^4.2.0"
+    "tape": "^4.2.0",
+    "virtex": "^0.1.18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "main": "lib/index.js",
   "scripts": {
     "prepublish": "rm -rf lib && babel src --out-dir lib",
-    "postpublish": "rm -rf lib"
+    "postpublish": "rm -rf lib",
+    "test": "babel-tape-runner test/*.js | tap-spec"
   },
   "dependencies": {
     "@micro-js/foreach": "^1.1.0",
@@ -21,7 +22,9 @@
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.1.18",
+    "babel-tape-runner": "^2.0.0",
     "standard": "^5.1.0",
+    "tap-spec": "^4.1.1",
     "tape": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "@micro-js/foreach": "^1.1.0",
     "@micro-js/is-object": "^1.0.0",
     "@micro-js/keychord": "^1.0.0",
-    "ev-store": "^7.0.0",
-    "to-style": "^1.3.3"
+    "ev-store": "^7.0.0"
   },
   "peerDependencies": {
     "virtex": "*"

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@
 import {element as _element} from 'virtex'
 import EvStore from 'ev-store'
 import events from './events'
-import {string as toStyle} from 'to-style'
 import forEach from '@micro-js/foreach'
 import isObject from '@micro-js/is-object'
 import keychord from '@micro-js/keychord'
@@ -66,6 +65,15 @@ function classSugar (value, name) {
   }
 
   return value
+}
+
+function toStyle (style) {
+  return Object.keys(style)
+    .map(property => {
+      const dashedProperty = property.replace(/([a-z][A-Z])/g, res => `${res[0]}-${res[1].toLowerCase()}`)
+      return `${dashedProperty}:${style[property]}`
+    })
+    .join(';')
 }
 
 function bindEvent (eventName, fn) {

--- a/test/index.js
+++ b/test/index.js
@@ -2,13 +2,22 @@
  * Imports
  */
 
+import element from '../src'
 import test from 'tape'
-import virtex-element from '../src'
 
 /**
  * Tests
  */
 
-test('should work', () => {
+test('style sugar: convert objects to strings', t => {
+  const div = element('div', {
+    style: {color: '#fff', backgroundColor: '#000'}
+  })
 
+  t.deepEqual(trim(div.props.style), 'color:#fff;background-color:#000')
+  t.end()
 })
+
+function trim (str) {
+  return str.replace(/ /g,'')
+}


### PR DESCRIPTION
`toStyle` is huge and way to opinionated. As a base element function, something simpler should do. A user can always add autoprefixing on top of it with something like [inline-style-prefixer](https://github.com/rofrischmann/inline-style-prefixer)

This pull request removes `to-style` dependency, adds just basic stringifying and converts camel cased properties to dashed onces.

If possible maybe even move it to @micro-js or we could open a new organization with vdux/dom/front-end related stuff.
